### PR TITLE
Path or pattern "assets/undefined.css" did not match any files [string exception]

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function postprocessTree(type, workingTree) {
 
         //sprites.css is appended to app.css,
         //so that two separate styles sheets do not need to get linked from index.html
-        var appCssFile = 'assets/' + this.app.options.name + '.css';
+        var appCssFile = 'assets/' + this.app.name + '.css';
         var spriteCssFile = this.app.options.sprite.stylesheetPath;
         var treeConcatCss = brocConcat(workingTree,  {
             inputFiles: [


### PR DESCRIPTION
This error occurs in my ember -cli v0.46 app, i did the update to v1.2 and the same error occurred.
I saw that the variable that will fetch the app name is wrong, this pull request fixed my issue.
Thanks
