### PR TITLE
Enable multiple sprites to be created

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ All the configuration options are exactly the same as those in
 The only thing that you need to do in addition is:
 
 - Put your images in the `public` folder (or a subfolder of `public`)
-- Add the options for `broccoli-sprite` under `sprite` when instantiating `EmberApp`:
+- Add an array of sprite options for `broccoli-sprite` under `sprite` when instantiating `EmberApp`: 
 
 For example, if the images you would like to be sprited are in `public/images/sprites`,
 you can configure your app like so:
 
     var app = new EmberApp({
-        /* other options */
-        sprite: {
+      /* other options */
+      sprite: [
+        {
           debug: true,
           src: [
             'images/sprites/**/*.png'
@@ -50,7 +51,11 @@ you can configure your app like so:
           layoutOptions: {
             padding: 2,
           }
+        },
+        {
+          // optional additional sprite
         }
+      ]
     });
 
 ## Road map

--- a/index.js
+++ b/index.js
@@ -7,51 +7,74 @@ var brocConcat = require('broccoli-concat');
 var brocDelete = require('broccoli-file-remover');
 var brocPickFiles = require('broccoli-static-compiler');
 
-module.exports.name = 'ember-sprite';
+module.exports = {
+  name: 'ember-sprite',
 
-module.exports.treeFor = function treeFor( /*inTree*/ ) {};
+  treeFor: function treeFor( /*inTree*/ ) {},
 
-module.exports.postprocessTree =
-function postprocessTree(type, workingTree) {
-    if (type === 'all') {
-        var spriteTree = brocPickFiles(workingTree, {
-            srcDir: '/',
-            files: this.app.options.sprite.src,
-            destDir: '/',
-        });
-        if (!!this.app.options.sprite.debug) {
-            console.log('spriteTree', util.inspect(workingTree, false, 6, true));
+  postprocessTree: function postprocessTree(type, workingTree) {
+      if (type === 'all' && this.app.options.sprite) {
+        var self = this;
+
+        // for backwards compatibility to previous implementation that passed plain object into sprite
+        // we push that object into an array we can iterate through to process the sprite(s)
+        if(Object.prototype.toString.call(this.app.options.sprite) === '[object Object]') {
+          var tmp = this.app.options.sprite;
+          this.app.options.sprite = [];
+          this.app.options.sprite.push(tmp);
         }
-        spriteTree = brocSprite(spriteTree, this.app.options.sprite);
-        workingTree = brocMergeTrees([
-            workingTree,
-            spriteTree
-        ]);
 
-        //sprites.css is appended to app.css,
-        //so that two separate styles sheets do not need to get linked from index.html
-        var appCssFile = 'assets/' + (this.app.name || this.app.project.pkg.name) + '.css';
-        var spriteCssFile = this.app.options.sprite.stylesheetPath;
-        var treeConcatCss = brocConcat(workingTree,  {
-            inputFiles: [
-                appCssFile,
-                spriteCssFile
-            ],
-            outputFile: '/'+appCssFile,
-            wrapInFunction: false,
+        // process each of the sprites that was passed in
+        this.app.options.sprite.forEach(function(sprite) {
+          workingTree = self._processSprite(sprite, workingTree);
         });
-        workingTree = brocMergeTrees([
-            workingTree,
-            treeConcatCss
-        ], {
-            overwrite: true,
-        });
-        workingTree = brocDelete(workingTree, {
-            files: [
-                spriteCssFile
-            ],
-        });
+      }
+
+      return workingTree;
+  },
+
+  _processSprite: function(sprite, workingTree) {
+
+    var spriteTree = brocPickFiles(workingTree, {
+        srcDir: '/',
+        files: sprite.src,
+        destDir: '/',
+    });
+
+    if (!!sprite.debug) {
+        console.log('spriteTree', util.inspect(workingTree, false, 6, true));
     }
+    spriteTree = brocSprite(spriteTree, sprite);
+    workingTree = brocMergeTrees([
+        workingTree,
+        spriteTree
+    ]);
+
+    //sprites.css is appended to app.css,
+    //so that two separate styles sheets do not need to get linked from index.html
+    var appCssFile = 'assets/' + (this.app.name || this.app.project.pkg.name) + '.css';
+    var spriteCssFile = sprite.stylesheetPath;
+    var treeConcatCss = brocConcat(workingTree,  {
+        inputFiles: [
+            appCssFile,
+            spriteCssFile
+        ],
+        outputFile: '/'+appCssFile,
+        wrapInFunction: false,
+    });
+
+    workingTree = brocMergeTrees([
+        workingTree,
+        treeConcatCss
+    ], {
+        overwrite: true,
+    });
+    workingTree = brocDelete(workingTree, {
+        files: [
+            spriteCssFile
+        ],
+    });
 
     return workingTree;
+  }
 };


### PR DESCRIPTION
This PR refactors the logic in this addon to allow for an array of sprites to be passed in and processed instead of just one like the current implementation.  The main use case for this is if you wanted to generate a sprite for retina screens alongside your standard sprite.

I made it so this change is backwards compatible with the previous implementation which passed in one object of options to the addon, but that should be discouraged going forward.

I also took this opportunity to re-organize how the functions in `index.js` were structured, but I didn't alter much functionality other than what was needed to allow us to iterate over the array of options passed in.