### PR TITLE
Update to broccoli-sprite@0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "broccoli-concat": "0.0.11",
     "broccoli-file-remover": "^0.2.3",
     "broccoli-merge-trees": "^0.1.4",
-    "broccoli-sprite": "^0.1.0",
+    "broccoli-sprite": "^0.2.0",
     "broccoli-static-compiler": "^0.1.4"
   },
   "ember-addon": {


### PR DESCRIPTION
> In the special case of zeroth-release version numbers, the carat is equivalent to the tilde.

For this reason, ember-sprite 0.4.0 is still resolving the latest 0.1.x release of broccoli-sprite