### PR TITLE
Add `stylesheetHeader` and `stylesheetFooter` support to individual stylesheets

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,27 @@ function _processSprite(sprite, workingTree) {
     var appCssFile = 'assets/' +
       (this.app.name || this.app.project.pkg.name) + '.css';
     var spriteCssFile = sprite.stylesheetPath;
+
+    var header = sprite.stylesheetHeader;
+    var footer = sprite.stylesheetFooter;
+
+    var wrapperTree = brocConcat(workingTree, {
+      inputFiles: [
+        spriteCssFile,
+      ],
+      outputFile: spriteCssFile,
+      header: header,
+      footer: footer,
+      wrapInFunction: false
+    });
+
+    workingTree = brocMergeTrees([
+      workingTree,
+      wrapperTree
+    ], {
+      overwrite: true,
+    });
+
     var treeConcatCss = brocConcat(workingTree,  {
         inputFiles: [
             appCssFile,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/bguiz/ember-sprite",
   "engines": {
-    "node": "4.2.x"
+    "node": ">= 4.0.0"
   },
   "author": "bguiz",
   "license": {


### PR DESCRIPTION
The use case is I need to wrap a stylesheet into a `@media` block, so I added 2 more options: `stylesheetHeader` and `stylesheetFooter`.

```js
sprite: [
  {
    debug: false,
    src: [
      'sprites/1x/*.png'
    ],
    spritePath: 'images/sprites.png',
    stylesheetPath: 'sprites.css',
    stylesheet: 'css',
    stylesheetOptions: {
      prefix: '',
      spritePath: '../images/sprites.png',
      pixelRatio: 1
    },
    layout: 'packed',
    layoutOptions: {
      padding: 2
    },
    optiping: true
  },
  {
    debug: false,
    src: [
      'sprites/2x/*.png'
    ],
    spritePath: 'images/sprites@2x.png',
    stylesheetPath: 'sprites@2x.css',
    stylesheet: 'css',
    stylesheetOptions: {
      prefix: '',
      spritePath: '../images/sprites@2x.png',
      pixelRatio: 2
    },
    stylesheetHeader: '@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2) {',
    stylesheetFooter: '}',
    layout: 'packed',
    layoutOptions: {
      padding: 2
    },
    optiping: true
  }
]
```