### PR TITLE
specify node >=4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-sprite",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "An ember addon which generates sprite sheets",
   "directories": {
     "doc": "doc",
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/bguiz/ember-sprite",
   "engines": {
-    "node": "4.2.x"
+    "node": ">=4.2.0"
   },
   "author": "bguiz",
   "license": {


### PR DESCRIPTION
This module is working fine under node 6.7.0, but [yarn](https://yarnpkg.com) refuses to install it because of the engines declaration in `package.json`:

```
error ember-sprite@0.7.0: The engine "node" is incompatible with this module. Expected version "4.2.x".
error Found incompatible module
```